### PR TITLE
Triple all user input character limits

### DIFF
--- a/client/src/components/game/ActionProposal.tsx
+++ b/client/src/components/game/ActionProposal.tsx
@@ -91,7 +91,7 @@ export function ActionProposal({ gameId, hasProposedThisRound, onProposed }: Act
           id="actionDescription"
           value={actionDescription}
           onChange={setActionDescription}
-          maxLength={500}
+          maxLength={1800}
           rows={3}
           placeholder="Describe the action you want to attempt..."
         />
@@ -105,7 +105,7 @@ export function ActionProposal({ gameId, hasProposedThisRound, onProposed }: Act
           id="desiredOutcome"
           value={desiredOutcome}
           onChange={setDesiredOutcome}
-          maxLength={300}
+          maxLength={1200}
           rows={2}
           placeholder="Describe your desired outcome..."
         />
@@ -123,7 +123,7 @@ export function ActionProposal({ gameId, hasProposedThisRound, onProposed }: Act
             <RichTextEditor
               value={arg}
               onChange={(value) => handleArgumentChange(index, value)}
-              maxLength={300}
+              maxLength={900}
               rows={2}
               placeholder={`Argument ${index + 1}${index === 0 ? ' (required)' : ' (optional)'}...`}
             />

--- a/client/src/components/game/AddArgument.tsx
+++ b/client/src/components/game/AddArgument.tsx
@@ -139,7 +139,7 @@ export function AddArgument({ actionId, gameId, remainingArguments, onAdded }: A
           id="argument-content"
           value={content}
           onChange={setContent}
-          maxLength={200}
+          maxLength={900}
           rows={3}
           placeholder={
             argumentType === 'FOR'

--- a/client/src/components/game/NarrationForm.tsx
+++ b/client/src/components/game/NarrationForm.tsx
@@ -247,7 +247,7 @@ export function NarrationForm({ gameId, action, currentUserId }: NarrationFormPr
             <RichTextEditor
               value={content}
               onChange={setContent}
-              maxLength={1000}
+              maxLength={3600}
               rows={6}
               placeholder="Describe what happens as a result of your action..."
             />

--- a/client/src/components/game/RoundSummary.tsx
+++ b/client/src/components/game/RoundSummary.tsx
@@ -82,8 +82,8 @@ export function RoundSummary({ gameId, roundId }: RoundSummaryProps) {
       return;
     }
 
-    if (content.length > 2000) {
-      setError('Summary must be 2000 characters or less');
+    if (content.length > 7500) {
+      setError('Summary must be 7500 characters or less');
       return;
     }
 
@@ -264,16 +264,16 @@ export function RoundSummary({ gameId, roundId }: RoundSummaryProps) {
               onChange={(e) => setContent(e.target.value)}
               className="w-full h-48 px-4 py-3 border rounded-lg bg-background resize-none focus:outline-none focus:ring-2 focus:ring-primary/50"
               placeholder="As the dust settled from this round's events..."
-              maxLength={2000}
+              maxLength={7500}
             />
             <div className="flex justify-between items-center mt-1">
               <span className="text-xs text-muted-foreground">
                 Summarize the events, consequences, and how the world has changed.
               </span>
               <span
-                className={`text-xs ${content.length > 1900 ? 'text-orange-500' : 'text-muted-foreground'}`}
+                className={`text-xs ${content.length > 7000 ? 'text-orange-500' : 'text-muted-foreground'}`}
               >
-                {content.length}/2000
+                {content.length}/7500
               </span>
             </div>
           </div>

--- a/client/src/pages/CreateGame.tsx
+++ b/client/src/pages/CreateGame.tsx
@@ -174,7 +174,7 @@ export default function CreateGame() {
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
-            maxLength={100}
+            maxLength={150}
             className="w-full px-3 py-2 border rounded-md bg-background"
             placeholder="My Matrix Game"
           />
@@ -189,7 +189,7 @@ export default function CreateGame() {
             aria-labelledby="description-label"
             value={description}
             onChange={setDescription}
-            maxLength={1200}
+            maxLength={3600}
             rows={4}
             placeholder="Describe the scenario or setting for your game..."
           />
@@ -283,7 +283,7 @@ export default function CreateGame() {
                       type="text"
                       value={persona.name}
                       onChange={(e) => updatePersona(index, 'name', e.target.value)}
-                      maxLength={50}
+                      maxLength={100}
                       className="flex-1 px-2 py-1 border rounded-md bg-background text-sm"
                       placeholder="Persona name"
                     />
@@ -298,7 +298,7 @@ export default function CreateGame() {
                   <RichTextEditor
                     value={persona.description}
                     onChange={(value) => updatePersona(index, 'description', value)}
-                    maxLength={500}
+                    maxLength={1800}
                     rows={2}
                     placeholder="Description (optional)"
                   />
@@ -327,7 +327,7 @@ export default function CreateGame() {
                         <RichTextEditor
                           value={persona.npcActionDescription || ''}
                           onChange={(value) => updatePersona(index, 'npcActionDescription', value)}
-                          maxLength={500}
+                          maxLength={1800}
                           rows={2}
                           placeholder="e.g., The dragon attacks the village"
                         />
@@ -339,7 +339,7 @@ export default function CreateGame() {
                         <RichTextEditor
                           value={persona.npcDesiredOutcome || ''}
                           onChange={(value) => updatePersona(index, 'npcDesiredOutcome', value)}
-                          maxLength={500}
+                          maxLength={1200}
                           rows={2}
                           placeholder="e.g., The village suffers significant losses"
                         />

--- a/server/src/utils/validators.ts
+++ b/server/src/utils/validators.ts
@@ -34,20 +34,19 @@ export const notificationPreferencesSchema = z.object({
 });
 
 // Persona schema
-// Note: Limits slightly increased to allow for markdown formatting (minimal overhead)
 export const personaSchema = z.object({
   name: z.string()
     .min(1, 'Persona name is required')
-    .max(50, 'Persona name must be 50 characters or less'),
+    .max(100, 'Persona name must be 100 characters or less'),
   description: z.string()
-    .max(600, 'Persona description must be 600 characters or less')
+    .max(1800, 'Persona description must be 1800 characters or less')
     .optional(),
   isNpc: z.boolean().default(false),
   npcActionDescription: z.string()
-    .max(600, 'NPC action description must be 600 characters or less')
+    .max(1800, 'NPC action description must be 1800 characters or less')
     .optional(),
   npcDesiredOutcome: z.string()
-    .max(400, 'NPC desired outcome must be 400 characters or less')
+    .max(1200, 'NPC desired outcome must be 1200 characters or less')
     .optional(),
 }).superRefine((data, ctx) => {
   if (data.isNpc) {
@@ -63,10 +62,9 @@ export const personaSchema = z.object({
 });
 
 // Game schemas
-// Note: Limits slightly increased to allow for markdown formatting (minimal overhead)
 export const createGameSchema = z.object({
-  name: z.string().min(1, 'Game name is required').max(100, 'Game name must be 100 characters or less'),
-  description: z.string().max(1200).optional(),
+  name: z.string().min(1, 'Game name is required').max(150, 'Game name must be 150 characters or less'),
+  description: z.string().max(3600).optional(),
   settings: z.object({
     argumentLimit: z.number().int().min(1).max(10).default(3),
     argumentationTimeoutHours: z.number().int().min(1).max(72).default(24),
@@ -87,33 +85,29 @@ export const selectPersonaSchema = z.object({
 });
 
 // Action schemas
-// Note: Limits slightly increased to allow for markdown formatting (minimal overhead)
 export const actionProposalSchema = z.object({
-  actionDescription: z.string().min(1, 'Action description is required').max(600, 'Action description must be 600 characters or less'),
-  desiredOutcome: z.string().min(1, 'Desired outcome is required').max(400, 'Desired outcome must be 400 characters or less'),
+  actionDescription: z.string().min(1, 'Action description is required').max(1800, 'Action description must be 1800 characters or less'),
+  desiredOutcome: z.string().min(1, 'Desired outcome is required').max(1200, 'Desired outcome must be 1200 characters or less'),
   initialArguments: z.array(
-    z.string().min(1).max(300, 'Each argument must be 300 characters or less')
+    z.string().min(1).max(900, 'Each argument must be 900 characters or less')
   ).min(1, 'At least one argument is required').max(3, 'Maximum 3 initial arguments'),
 });
 
-// Note: Limit slightly increased to allow for markdown formatting (minimal overhead)
 export const argumentSchema = z.object({
   argumentType: z.enum(['FOR', 'AGAINST', 'CLARIFICATION']),
-  content: z.string().min(1, 'Argument content is required').max(300, 'Argument must be 300 characters or less'),
+  content: z.string().min(1, 'Argument content is required').max(900, 'Argument must be 900 characters or less'),
 });
 
 export const voteSchema = z.object({
   voteType: z.enum(['LIKELY_SUCCESS', 'LIKELY_FAILURE', 'UNCERTAIN']),
 });
 
-// Note: Limit slightly increased to allow for markdown formatting (minimal overhead)
 export const narrationSchema = z.object({
-  content: z.string().min(1, 'Narration is required').max(1200, 'Narration must be 1200 characters or less'),
+  content: z.string().min(1, 'Narration is required').max(3600, 'Narration must be 3600 characters or less'),
 });
 
-// Note: Limit slightly increased to allow for markdown formatting (minimal overhead)
 export const roundSummarySchema = z.object({
-  content: z.string().min(1, 'Summary is required').max(2500, 'Summary must be 2500 characters or less'),
+  content: z.string().min(1, 'Summary is required').max(7500, 'Summary must be 7500 characters or less'),
   outcomes: z.object({
     totalTriumphs: z.number().int().min(0).optional(),
     totalDisasters: z.number().int().min(0).optional(),

--- a/server/tests/unit/validators.test.ts
+++ b/server/tests/unit/validators.test.ts
@@ -13,16 +13,16 @@ const registerSchema = z.object({
 });
 
 const personaSchema = z.object({
-  name: z.string().min(1, 'Persona name is required').max(50),
-  description: z.string().max(600).optional(),
+  name: z.string().min(1, 'Persona name is required').max(100),
+  description: z.string().max(1800).optional(),
   isNpc: z.boolean().default(false),
-  npcActionDescription: z.string().max(600).optional(),
-  npcDesiredOutcome: z.string().max(400).optional(),
+  npcActionDescription: z.string().max(1800).optional(),
+  npcDesiredOutcome: z.string().max(1200).optional(),
 });
 
 const createGameSchema = z.object({
-  name: z.string().min(1, 'Game name is required').max(100, 'Game name must be 100 characters or less'),
-  description: z.string().max(1000).optional(),
+  name: z.string().min(1, 'Game name is required').max(150, 'Game name must be 150 characters or less'),
+  description: z.string().max(3600).optional(),
   settings: z.object({
     argumentLimit: z.number().int().min(1).max(10).default(3),
     argumentationTimeoutHours: z.number().int().min(1).max(72).default(24),
@@ -33,14 +33,14 @@ const createGameSchema = z.object({
 });
 
 const actionProposalSchema = z.object({
-  actionDescription: z.string().min(1).max(500),
-  desiredOutcome: z.string().min(1).max(300),
-  initialArguments: z.array(z.string().min(1).max(200)).min(1).max(3),
+  actionDescription: z.string().min(1).max(1800),
+  desiredOutcome: z.string().min(1).max(1200),
+  initialArguments: z.array(z.string().min(1).max(900)).min(1).max(3),
 });
 
 const argumentSchema = z.object({
   argumentType: z.enum(['FOR', 'AGAINST', 'CLARIFICATION']),
-  content: z.string().min(1).max(200),
+  content: z.string().min(1).max(900),
 });
 
 const voteSchema = z.object({
@@ -48,7 +48,7 @@ const voteSchema = z.object({
 });
 
 const narrationSchema = z.object({
-  content: z.string().min(1).max(1000),
+  content: z.string().min(1).max(3600),
 });
 
 describe('Validators', () => {
@@ -145,13 +145,13 @@ describe('Validators', () => {
       expect(() => createGameSchema.parse(data)).toThrow();
     });
 
-    it('should reject game name over 100 chars', () => {
-      const data = { name: 'a'.repeat(101) };
+    it('should reject game name over 150 chars', () => {
+      const data = { name: 'a'.repeat(151) };
       expect(() => createGameSchema.parse(data)).toThrow();
     });
 
-    it('should reject description over 1000 chars', () => {
-      const data = { name: 'Test', description: 'a'.repeat(1001) };
+    it('should reject description over 3600 chars', () => {
+      const data = { name: 'Test', description: 'a'.repeat(3601) };
       expect(() => createGameSchema.parse(data)).toThrow();
     });
 
@@ -213,29 +213,29 @@ describe('Validators', () => {
       expect(() => actionProposalSchema.parse(data)).toThrow();
     });
 
-    it('should reject action description over 500 chars', () => {
+    it('should reject action description over 1800 chars', () => {
       const data = {
-        actionDescription: 'a'.repeat(501),
+        actionDescription: 'a'.repeat(1801),
         desiredOutcome: 'Success',
         initialArguments: ['Arg'],
       };
       expect(() => actionProposalSchema.parse(data)).toThrow();
     });
 
-    it('should reject desired outcome over 300 chars', () => {
+    it('should reject desired outcome over 1200 chars', () => {
       const data = {
         actionDescription: 'Action',
-        desiredOutcome: 'a'.repeat(301),
+        desiredOutcome: 'a'.repeat(1201),
         initialArguments: ['Arg'],
       };
       expect(() => actionProposalSchema.parse(data)).toThrow();
     });
 
-    it('should reject argument over 200 chars', () => {
+    it('should reject argument over 900 chars', () => {
       const data = {
         actionDescription: 'Action',
         desiredOutcome: 'Outcome',
-        initialArguments: ['a'.repeat(201)],
+        initialArguments: ['a'.repeat(901)],
       };
       expect(() => actionProposalSchema.parse(data)).toThrow();
     });
@@ -267,8 +267,8 @@ describe('Validators', () => {
       expect(() => argumentSchema.parse(data)).toThrow();
     });
 
-    it('should reject content over 200 chars', () => {
-      const data = { argumentType: 'FOR', content: 'a'.repeat(201) };
+    it('should reject content over 900 chars', () => {
+      const data = { argumentType: 'FOR', content: 'a'.repeat(901) };
       expect(() => argumentSchema.parse(data)).toThrow();
     });
   });
@@ -306,13 +306,13 @@ describe('Validators', () => {
       expect(() => narrationSchema.parse(data)).toThrow();
     });
 
-    it('should reject narration over 1000 chars', () => {
-      const data = { content: 'a'.repeat(1001) };
+    it('should reject narration over 3600 chars', () => {
+      const data = { content: 'a'.repeat(3601) };
       expect(() => narrationSchema.parse(data)).toThrow();
     });
 
     it('should accept narration at max length', () => {
-      const data = { content: 'a'.repeat(1000) };
+      const data = { content: 'a'.repeat(3600) };
       expect(() => narrationSchema.parse(data)).not.toThrow();
     });
   });
@@ -338,25 +338,25 @@ describe('Validators', () => {
       expect(() => personaSchema.parse(data)).toThrow();
     });
 
-    it('should reject persona with name over 50 chars', () => {
-      const data = { name: 'a'.repeat(51) };
+    it('should reject persona with name over 100 chars', () => {
+      const data = { name: 'a'.repeat(101) };
       expect(() => personaSchema.parse(data)).toThrow();
     });
 
-    it('should reject NPC action description over 600 chars', () => {
+    it('should reject NPC action description over 1800 chars', () => {
       const data = {
         name: 'Dragon',
         isNpc: true,
-        npcActionDescription: 'a'.repeat(601),
+        npcActionDescription: 'a'.repeat(1801),
       };
       expect(() => personaSchema.parse(data)).toThrow();
     });
 
-    it('should reject NPC desired outcome over 400 chars', () => {
+    it('should reject NPC desired outcome over 1200 chars', () => {
       const data = {
         name: 'Dragon',
         isNpc: true,
-        npcDesiredOutcome: 'a'.repeat(401),
+        npcDesiredOutcome: 'a'.repeat(1201),
       };
       expect(() => personaSchema.parse(data)).toThrow();
     });


### PR DESCRIPTION
Increase all content-related limits to allow more detailed inputs:
- Game name: 100 → 150 chars
- Game description: 1200 → 3600 chars
- Persona name: 50 → 100 chars
- Persona description: 600 → 1800 chars
- NPC action description: 600 → 1800 chars
- NPC desired outcome: 400 → 1200 chars
- Action description: 600 → 1800 chars
- Desired outcome: 400 → 1200 chars
- Arguments: 300 → 900 chars
- Narration: 1200 → 3600 chars
- Round summary: 2500 → 7500 chars

Updated both backend validators and frontend components.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
