### PR TITLE
Add host skip controls for game phases

### DIFF
--- a/client/src/components/game/GameHistory.tsx
+++ b/client/src/components/game/GameHistory.tsx
@@ -21,6 +21,8 @@ interface HistoryAction {
   sequenceNumber: number;
   actionDescription: string;
   desiredOutcome: string;
+  argumentationWasSkipped?: boolean;
+  votingWasSkipped?: boolean;
   initiator: {
     playerName: string;
     user: { displayName: string };
@@ -30,6 +32,7 @@ interface HistoryAction {
     totalSuccessTokens: number;
     totalFailureTokens: number;
     voteCount: number;
+    skippedVotes?: number;
   };
   tokenDraw?: {
     resultValue: number;
@@ -207,11 +210,21 @@ export function GameHistory({ gameId, compact = false }: GameHistoryProps) {
               <div className="space-y-3">
                 <div className="flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
+                    <div className="flex items-center gap-2 mb-1 flex-wrap">
                       <span className="text-xs text-muted-foreground">
                         #{action.sequenceNumber}
                       </span>
                       <span className="text-sm font-medium">{action.initiator.playerName}</span>
+                      {action.argumentationWasSkipped && (
+                        <span className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded">
+                          Args skipped
+                        </span>
+                      )}
+                      {action.votingWasSkipped && (
+                        <span className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded">
+                          Votes skipped
+                        </span>
+                      )}
                     </div>
                     <p className="text-sm">{action.actionDescription}</p>
                   </div>
@@ -242,7 +255,7 @@ export function GameHistory({ gameId, compact = false }: GameHistoryProps) {
 
                 {/* Token Pool Summary */}
                 {action.voteTotals && (
-                  <div className="flex items-center gap-3 text-xs">
+                  <div className="flex items-center gap-3 text-xs flex-wrap">
                     <span className="text-muted-foreground">Token Pool:</span>
                     <span className="text-green-600 dark:text-green-400">
                       {action.voteTotals.totalSuccessTokens} Success
@@ -251,7 +264,7 @@ export function GameHistory({ gameId, compact = false }: GameHistoryProps) {
                       {action.voteTotals.totalFailureTokens} Failure
                     </span>
                     <span className="text-muted-foreground">
-                      ({action.voteTotals.voteCount} votes)
+                      ({action.voteTotals.voteCount} votes{action.voteTotals.skippedVotes ? `, ${action.voteTotals.skippedVotes} auto-filled` : ''})
                     </span>
                   </div>
                 )}

--- a/client/src/components/game/HostControls.tsx
+++ b/client/src/components/game/HostControls.tsx
@@ -1,0 +1,185 @@
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../../services/api';
+
+interface HostControlsProps {
+  gameId: string;
+  currentPhase: string;
+  currentActionId?: string;
+  isHost: boolean;
+}
+
+export function HostControls({
+  gameId,
+  currentPhase,
+  currentActionId,
+  isHost,
+}: HostControlsProps) {
+  const queryClient = useQueryClient();
+  const [confirmSkip, setConfirmSkip] = useState<string | null>(null);
+
+  const skipProposalsMutation = useMutation({
+    mutationFn: () => api.post(`/games/${gameId}/skip-proposals`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['game', gameId] });
+      setConfirmSkip(null);
+    },
+  });
+
+  const skipArgumentationMutation = useMutation({
+    mutationFn: () => api.post(`/actions/${currentActionId}/skip-argumentation`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['game', gameId] });
+      setConfirmSkip(null);
+    },
+  });
+
+  const skipVotingMutation = useMutation({
+    mutationFn: () => api.post(`/actions/${currentActionId}/skip-voting`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['game', gameId] });
+      setConfirmSkip(null);
+    },
+  });
+
+  if (!isHost) {
+    return null;
+  }
+
+  const renderSkipButton = () => {
+    // Determine which skip action is available based on current phase
+    if (currentPhase === 'PROPOSAL' && !currentActionId) {
+      // In proposal phase waiting for proposals
+      return (
+        <SkipConfirmButton
+          label="Skip Remaining Proposals"
+          description="End the proposal phase and move to round summary. At least one action must have been proposed."
+          confirmKey="proposals"
+          confirmSkip={confirmSkip}
+          setConfirmSkip={setConfirmSkip}
+          isLoading={skipProposalsMutation.isPending}
+          onConfirm={() => skipProposalsMutation.mutate()}
+          error={skipProposalsMutation.error}
+        />
+      );
+    }
+
+    if (currentPhase === 'ARGUMENTATION' && currentActionId) {
+      return (
+        <SkipConfirmButton
+          label="Skip Argumentation"
+          description="End the argumentation phase early and move to voting."
+          confirmKey="argumentation"
+          confirmSkip={confirmSkip}
+          setConfirmSkip={setConfirmSkip}
+          isLoading={skipArgumentationMutation.isPending}
+          onConfirm={() => skipArgumentationMutation.mutate()}
+          error={skipArgumentationMutation.error}
+        />
+      );
+    }
+
+    if (currentPhase === 'VOTING' && currentActionId) {
+      return (
+        <SkipConfirmButton
+          label="Skip Voting"
+          description="End the voting phase. Missing votes will be auto-filled as 'Uncertain'."
+          confirmKey="voting"
+          confirmSkip={confirmSkip}
+          setConfirmSkip={setConfirmSkip}
+          isLoading={skipVotingMutation.isPending}
+          onConfirm={() => skipVotingMutation.mutate()}
+          error={skipVotingMutation.error}
+        />
+      );
+    }
+
+    return null;
+  };
+
+  const skipButton = renderSkipButton();
+
+  if (!skipButton) {
+    return null;
+  }
+
+  return (
+    <div className="p-4 border rounded-lg bg-amber-50/50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800">
+      <h3 className="font-semibold mb-2 flex items-center gap-2 text-amber-800 dark:text-amber-200">
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        Host Controls
+      </h3>
+      {skipButton}
+    </div>
+  );
+}
+
+interface SkipConfirmButtonProps {
+  label: string;
+  description: string;
+  confirmKey: string;
+  confirmSkip: string | null;
+  setConfirmSkip: (key: string | null) => void;
+  isLoading: boolean;
+  onConfirm: () => void;
+  error: Error | null;
+}
+
+function SkipConfirmButton({
+  label,
+  description,
+  confirmKey,
+  confirmSkip,
+  setConfirmSkip,
+  isLoading,
+  onConfirm,
+  error,
+}: SkipConfirmButtonProps) {
+  const isConfirming = confirmSkip === confirmKey;
+
+  if (isConfirming) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-amber-700 dark:text-amber-300">{description}</p>
+        <div className="flex gap-2">
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="px-3 py-1.5 text-sm bg-amber-600 hover:bg-amber-700 text-white rounded-md disabled:opacity-50"
+          >
+            {isLoading ? 'Skipping...' : 'Confirm Skip'}
+          </button>
+          <button
+            onClick={() => setConfirmSkip(null)}
+            disabled={isLoading}
+            className="px-3 py-1.5 text-sm border border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50 rounded-md"
+          >
+            Cancel
+          </button>
+        </div>
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {(error as { response?: { data?: { message?: string } } })?.response?.data?.message ||
+              'Failed to skip'}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setConfirmSkip(confirmKey)}
+      className="w-full px-3 py-2 text-sm text-amber-700 dark:text-amber-300 border border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/50 rounded-md transition-colors"
+    >
+      {label}
+    </button>
+  );
+}

--- a/client/src/components/game/RoundHistory.tsx
+++ b/client/src/components/game/RoundHistory.tsx
@@ -12,6 +12,8 @@ interface RoundAction {
   sequenceNumber: number;
   actionDescription: string;
   initiatorId: string;
+  argumentationWasSkipped?: boolean;
+  votingWasSkipped?: boolean;
   tokenDraw?: {
     resultValue: number;
     resultType: 'TRIUMPH' | 'SUCCESS_BUT' | 'FAILURE_BUT' | 'DISASTER';
@@ -242,6 +244,16 @@ export function RoundHistory({ gameId, currentRoundNumber }: RoundHistoryProps) 
                               <span className="text-xs text-muted-foreground">
                                 #{index + 1}
                               </span>
+                              {action.argumentationWasSkipped && (
+                                <span className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded">
+                                  Args skipped
+                                </span>
+                              )}
+                              {action.votingWasSkipped && (
+                                <span className="text-xs bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded">
+                                  Votes skipped
+                                </span>
+                              )}
                             </div>
                             <p className="text-sm">{action.actionDescription}</p>
                           </div>

--- a/client/src/components/game/index.ts
+++ b/client/src/components/game/index.ts
@@ -8,3 +8,4 @@ export { NarrationForm } from './NarrationForm';
 export { RoundSummary } from './RoundSummary';
 export { GameHistory } from './GameHistory';
 export { RoundHistory } from './RoundHistory';
+export { HostControls } from './HostControls';

--- a/client/src/pages/GameView.tsx
+++ b/client/src/pages/GameView.tsx
@@ -12,6 +12,7 @@ import {
   RoundSummary,
   GameHistory,
   RoundHistory,
+  HostControls,
 } from '../components/game';
 import { Skeleton, SkeletonText } from '../components/ui/Skeleton';
 
@@ -364,6 +365,14 @@ export default function GameView() {
             <h3 className="font-semibold mb-2">Phase Guide</h3>
             <PhaseGuide phase={game.currentPhase} />
           </div>
+
+          {/* Host Controls for skipping phases */}
+          <HostControls
+            gameId={game.id}
+            currentPhase={game.currentPhase}
+            currentActionId={game.currentAction?.id}
+            isHost={myPlayer?.isHost || false}
+          />
 
           {/* Players */}
           <div className="p-4 border rounded-lg">

--- a/docs/API.md
+++ b/docs/API.md
@@ -435,6 +435,69 @@ Submit narration for the action outcome (initiator only).
 ### GET /actions/:actionId/narration
 Get the narration for an action.
 
+### POST /actions/:actionId/skip-argumentation
+Skip the argumentation phase (host only). Moves the action directly to voting phase.
+
+**Response:** `200 OK`
+```json
+{
+  "success": true,
+  "data": {
+    "message": "Argumentation skipped, moved to voting phase"
+  }
+}
+```
+
+**Notes:**
+- Only the game host can skip phases
+- Action must be in ARGUING status
+- Sets `argumentationWasSkipped: true` on the action for history tracking
+
+### POST /actions/:actionId/skip-voting
+Skip the voting phase (host only). Auto-fills missing votes as UNCERTAIN and moves to resolution.
+
+**Response:** `200 OK`
+```json
+{
+  "success": true,
+  "data": {
+    "message": "Voting skipped, moved to resolution phase",
+    "skippedVotes": 2
+  }
+}
+```
+
+**Notes:**
+- Only the game host can skip phases
+- Action must be in VOTING status
+- Missing votes are auto-filled as UNCERTAIN (1 success, 1 failure token)
+- Auto-filled votes have `wasSkipped: true` for history tracking
+- Sets `votingWasSkipped: true` on the action
+
+---
+
+## Games (Host Skip Controls)
+
+### POST /games/:gameId/skip-proposals
+Skip remaining proposals and move to round summary (host only). Ends the proposal phase early.
+
+**Response:** `200 OK`
+```json
+{
+  "success": true,
+  "data": {
+    "message": "Remaining proposals skipped, moved to round summary",
+    "completedActions": 2
+  }
+}
+```
+
+**Notes:**
+- Only the game host can skip proposals
+- Game must be in PROPOSAL phase with no current action (waiting for proposals)
+- At least one action must have been proposed in the current round
+- Updates round's `totalActionsRequired` to match completed actions
+
 ---
 
 ## Rounds

--- a/server/prisma/migrations/20260206145254_add_skip_tracking_fields/migration.sql
+++ b/server/prisma/migrations/20260206145254_add_skip_tracking_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "actions" ADD COLUMN     "argumentation_was_skipped" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "voting_was_skipped" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "votes" ADD COLUMN     "was_skipped" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -158,19 +158,21 @@ model Persona {
 }
 
 model Action {
-  id                     String       @id @default(uuid())
-  gameId                 String       @map("game_id")
-  roundId                String       @map("round_id")
-  initiatorId            String       @map("initiator_id")
-  sequenceNumber         Int          @map("sequence_number")
-  actionDescription      String       @map("action_description") @db.Text
-  desiredOutcome         String       @map("desired_outcome") @db.Text
-  status                 ActionStatus @default(PROPOSED)
-  proposedAt             DateTime     @default(now()) @map("proposed_at")
-  argumentationStartedAt DateTime?    @map("argumentation_started_at")
-  votingStartedAt        DateTime?    @map("voting_started_at")
-  resolvedAt             DateTime?    @map("resolved_at")
-  completedAt            DateTime?    @map("completed_at")
+  id                      String       @id @default(uuid())
+  gameId                  String       @map("game_id")
+  roundId                 String       @map("round_id")
+  initiatorId             String       @map("initiator_id")
+  sequenceNumber          Int          @map("sequence_number")
+  actionDescription       String       @map("action_description") @db.Text
+  desiredOutcome          String       @map("desired_outcome") @db.Text
+  status                  ActionStatus @default(PROPOSED)
+  argumentationWasSkipped Boolean      @default(false) @map("argumentation_was_skipped")
+  votingWasSkipped        Boolean      @default(false) @map("voting_was_skipped")
+  proposedAt              DateTime     @default(now()) @map("proposed_at")
+  argumentationStartedAt  DateTime?    @map("argumentation_started_at")
+  votingStartedAt         DateTime?    @map("voting_started_at")
+  resolvedAt              DateTime?    @map("resolved_at")
+  completedAt             DateTime?    @map("completed_at")
 
   // Relations
   game                   Game                   @relation("GameActions", fields: [gameId], references: [id], onDelete: Cascade)
@@ -217,6 +219,7 @@ model Vote {
   voteType      VoteType @map("vote_type")
   successTokens Int      @map("success_tokens")
   failureTokens Int      @map("failure_tokens")
+  wasSkipped    Boolean  @default(false) @map("was_skipped")
   castAt        DateTime @default(now()) @map("cast_at")
 
   // Relations

--- a/server/src/controllers/action.controller.ts
+++ b/server/src/controllers/action.controller.ts
@@ -154,3 +154,33 @@ export async function getNarration(
     next(error);
   }
 }
+
+export async function skipArgumentation(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const actionId = req.params.actionId as string;
+    const userId = req.user!.id;
+    const result = await actionService.skipArgumentation(actionId, userId);
+    res.json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function skipVoting(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const actionId = req.params.actionId as string;
+    const userId = req.user!.id;
+    const result = await actionService.skipVoting(actionId, userId);
+    res.json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}

--- a/server/src/controllers/game.controller.ts
+++ b/server/src/controllers/game.controller.ts
@@ -232,3 +232,18 @@ export async function uploadGameImage(
   }
 }
 
+export async function skipProposals(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const gameId = req.params.gameId as string;
+    const userId = req.user!.id;
+    const result = await actionService.skipToNextAction(gameId, userId);
+    res.json({ success: true, data: result });
+  } catch (error) {
+    next(error);
+  }
+}
+

--- a/server/src/routes/action.routes.ts
+++ b/server/src/routes/action.routes.ts
@@ -15,4 +15,8 @@ router.get('/:actionId/draw', authenticateToken, actionController.getDrawResult)
 router.post('/:actionId/narration', authenticateToken, actionController.submitNarration);
 router.get('/:actionId/narration', authenticateToken, actionController.getNarration);
 
+// Host skip controls
+router.post('/:actionId/skip-argumentation', authenticateToken, actionController.skipArgumentation);
+router.post('/:actionId/skip-voting', authenticateToken, actionController.skipVoting);
+
 export default router;

--- a/server/src/routes/game.routes.ts
+++ b/server/src/routes/game.routes.ts
@@ -20,4 +20,7 @@ router.get('/:gameId/history', authenticateToken, gameController.getGameHistory)
 router.get('/:gameId/rounds', authenticateToken, gameController.getRounds);
 router.post('/:gameId/actions', authenticateToken, gameController.proposeAction);
 
+// Host skip controls
+router.post('/:gameId/skip-proposals', authenticateToken, gameController.skipProposals);
+
 export default router;

--- a/server/src/services/game.service.ts
+++ b/server/src/services/game.service.ts
@@ -562,6 +562,7 @@ export async function getGameHistory(gameId: string, userId: string) {
           voteType: true,
           successTokens: true,
           failureTokens: true,
+          wasSkipped: true,
         },
       },
       tokenDraw: true,
@@ -577,8 +578,9 @@ export async function getGameHistory(gameId: string, userId: string) {
         totalSuccessTokens: acc.totalSuccessTokens + vote.successTokens,
         totalFailureTokens: acc.totalFailureTokens + vote.failureTokens,
         voteCount: acc.voteCount + 1,
+        skippedVotes: acc.skippedVotes + (vote.wasSkipped ? 1 : 0),
       }),
-      { totalSuccessTokens: 1, totalFailureTokens: 1, voteCount: 0 } // Base pool of 1+1
+      { totalSuccessTokens: 1, totalFailureTokens: 1, voteCount: 0, skippedVotes: 0 } // Base pool of 1+1
     );
 
     return {

--- a/server/tests/unit/services/action.skip.test.ts
+++ b/server/tests/unit/services/action.skip.test.ts
@@ -1,0 +1,485 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the database
+vi.mock('../../../src/config/database.js', () => ({
+  db: {
+    action: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+      count: vi.fn(),
+    },
+    game: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    gamePlayer: {
+      findFirst: vi.fn(),
+    },
+    vote: {
+      createMany: vi.fn(),
+    },
+    round: {
+      update: vi.fn(),
+    },
+    gameEvent: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+// Mock notification service
+vi.mock('../../../src/services/notification.service.js', () => ({
+  notifyVotingStarted: vi.fn().mockResolvedValue(undefined),
+  notifyResolutionReady: vi.fn().mockResolvedValue(undefined),
+  notifyRoundSummaryNeeded: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock game service exports
+vi.mock('../../../src/services/game.service.js', () => ({
+  requireMember: vi.fn().mockResolvedValue({ id: 'player-1', userId: 'user-1' }),
+  logGameEvent: vi.fn().mockResolvedValue({}),
+  transitionPhase: vi.fn().mockResolvedValue({}),
+}));
+
+import { db } from '../../../src/config/database.js';
+import * as actionService from '../../../src/services/action.service.js';
+import { NotFoundError, ForbiddenError, BadRequestError } from '../../../src/middleware/errorHandler.js';
+
+describe('Action Service - Skip Functionality', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('skipArgumentation', () => {
+    it('should skip argumentation and transition to voting when host requests', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'ARGUING',
+        actionDescription: 'Test action',
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [
+            { id: 'player-1', userId: 'user-1', isHost: true, isActive: true, isNpc: false },
+            { id: 'player-2', userId: 'user-2', isHost: false, isActive: true, isNpc: false },
+          ],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.action.update).mockResolvedValue({
+        ...mockAction,
+        status: 'VOTING',
+        argumentationWasSkipped: true,
+        votingStartedAt: new Date(),
+      } as any);
+
+      const result = await actionService.skipArgumentation('action-1', 'user-1');
+
+      expect(result.message).toBe('Argumentation skipped, moved to voting phase');
+      expect(db.action.update).toHaveBeenCalledWith({
+        where: { id: 'action-1' },
+        data: {
+          status: 'VOTING',
+          votingStartedAt: expect.any(Date),
+          argumentationWasSkipped: true,
+        },
+      });
+    });
+
+    it('should throw error if user is not host', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'ARGUING',
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [
+            { id: 'player-1', userId: 'user-1', isHost: true, isActive: true, isNpc: false },
+            { id: 'player-2', userId: 'user-2', isHost: false, isActive: true, isNpc: false },
+          ],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue(null); // Not a host
+
+      await expect(actionService.skipArgumentation('action-1', 'user-2')).rejects.toThrow(
+        ForbiddenError
+      );
+    });
+
+    it('should throw error if action is not in ARGUING phase', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'VOTING', // Wrong phase
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+
+      await expect(actionService.skipArgumentation('action-1', 'user-1')).rejects.toThrow(
+        new BadRequestError('Action is not in argumentation phase')
+      );
+    });
+
+    it('should throw error if action not found', async () => {
+      vi.mocked(db.action.findUnique).mockResolvedValue(null);
+
+      await expect(actionService.skipArgumentation('action-1', 'user-1')).rejects.toThrow(
+        NotFoundError
+      );
+    });
+  });
+
+  describe('skipVoting', () => {
+    it('should skip voting, auto-fill missing votes, and transition to resolution', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'VOTING',
+        actionDescription: 'Test action',
+        votes: [
+          { playerId: 'player-1', voteType: 'LIKELY_SUCCESS' },
+        ],
+        initiator: {
+          userId: 'user-1',
+        },
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [
+            { id: 'player-1', userId: 'user-1', isHost: true, isActive: true, isNpc: false, playerName: 'Player 1' },
+            { id: 'player-2', userId: 'user-2', isHost: false, isActive: true, isNpc: false, playerName: 'Player 2' },
+            { id: 'player-3', userId: 'user-3', isHost: false, isActive: true, isNpc: false, playerName: 'Player 3' },
+          ],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.vote.createMany).mockResolvedValue({ count: 2 } as any);
+      vi.mocked(db.action.update).mockResolvedValue({
+        ...mockAction,
+        status: 'RESOLVED',
+        votingWasSkipped: true,
+      } as any);
+
+      const result = await actionService.skipVoting('action-1', 'user-1');
+
+      expect(result.message).toBe('Voting skipped, moved to resolution phase');
+      expect(result.skippedVotes).toBe(2);
+      expect(db.vote.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            actionId: 'action-1',
+            playerId: 'player-2',
+            voteType: 'UNCERTAIN',
+            successTokens: 1,
+            failureTokens: 1,
+            wasSkipped: true,
+          },
+          {
+            actionId: 'action-1',
+            playerId: 'player-3',
+            voteType: 'UNCERTAIN',
+            successTokens: 1,
+            failureTokens: 1,
+            wasSkipped: true,
+          },
+        ],
+      });
+      expect(db.action.update).toHaveBeenCalledWith({
+        where: { id: 'action-1' },
+        data: {
+          status: 'RESOLVED',
+          votingWasSkipped: true,
+        },
+      });
+    });
+
+    it('should handle case when all votes are already submitted', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'VOTING',
+        actionDescription: 'Test action',
+        votes: [
+          { playerId: 'player-1', voteType: 'LIKELY_SUCCESS' },
+          { playerId: 'player-2', voteType: 'LIKELY_FAILURE' },
+        ],
+        initiator: {
+          userId: 'user-1',
+        },
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [
+            { id: 'player-1', userId: 'user-1', isHost: true, isActive: true, isNpc: false, playerName: 'Player 1' },
+            { id: 'player-2', userId: 'user-2', isHost: false, isActive: true, isNpc: false, playerName: 'Player 2' },
+          ],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.action.update).mockResolvedValue({
+        ...mockAction,
+        status: 'RESOLVED',
+        votingWasSkipped: true,
+      } as any);
+
+      const result = await actionService.skipVoting('action-1', 'user-1');
+
+      expect(result.skippedVotes).toBe(0);
+      expect(db.vote.createMany).not.toHaveBeenCalled();
+    });
+
+    it('should exclude NPC from vote counting', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'VOTING',
+        actionDescription: 'Test action',
+        votes: [
+          { playerId: 'player-1', voteType: 'LIKELY_SUCCESS' },
+        ],
+        initiator: {
+          userId: 'user-1',
+        },
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [
+            { id: 'player-1', userId: 'user-1', isHost: true, isActive: true, isNpc: false, playerName: 'Player 1' },
+            { id: 'player-2', userId: 'user-2', isHost: false, isActive: true, isNpc: false, playerName: 'Player 2' },
+            { id: 'player-npc', userId: 'npc-user', isHost: false, isActive: true, isNpc: true, playerName: 'NPC' },
+          ],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.vote.createMany).mockResolvedValue({ count: 1 } as any);
+      vi.mocked(db.action.update).mockResolvedValue({
+        ...mockAction,
+        status: 'RESOLVED',
+        votingWasSkipped: true,
+      } as any);
+
+      const result = await actionService.skipVoting('action-1', 'user-1');
+
+      // Only player-2 should have missing vote (NPC is excluded)
+      expect(result.skippedVotes).toBe(1);
+      expect(db.vote.createMany).toHaveBeenCalledWith({
+        data: [
+          {
+            actionId: 'action-1',
+            playerId: 'player-2',
+            voteType: 'UNCERTAIN',
+            successTokens: 1,
+            failureTokens: 1,
+            wasSkipped: true,
+          },
+        ],
+      });
+    });
+
+    it('should throw error if action is not in VOTING phase', async () => {
+      const mockAction = {
+        id: 'action-1',
+        gameId: 'game-1',
+        status: 'ARGUING', // Wrong phase
+        votes: [],
+        initiator: { userId: 'user-1' },
+        game: {
+          id: 'game-1',
+          name: 'Test Game',
+          players: [],
+        },
+      };
+
+      vi.mocked(db.action.findUnique).mockResolvedValue(mockAction as any);
+
+      await expect(actionService.skipVoting('action-1', 'user-1')).rejects.toThrow(
+        new BadRequestError('Action is not in voting phase')
+      );
+    });
+  });
+
+  describe('skipToNextAction (skipProposals)', () => {
+    it('should skip proposals and move to round summary when at least one action exists', async () => {
+      const mockGame = {
+        id: 'game-1',
+        name: 'Test Game',
+        currentPhase: 'PROPOSAL',
+        currentActionId: null, // Waiting for proposals
+        deletedAt: null,
+        currentRound: {
+          id: 'round-1',
+          roundNumber: 1,
+          actionsCompleted: 2,
+          totalActionsRequired: 4,
+        },
+        currentAction: null,
+        players: [
+          { id: 'player-1', userId: 'user-1', isHost: true, isActive: true },
+          { id: 'player-2', userId: 'user-2', isHost: false, isActive: true },
+        ],
+      };
+
+      vi.mocked(db.game.findUnique).mockResolvedValue(mockGame as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.action.count).mockResolvedValue(2);
+      vi.mocked(db.round.update).mockResolvedValue({
+        ...mockGame.currentRound,
+        totalActionsRequired: 2,
+        actionsCompleted: 2,
+      } as any);
+
+      const result = await actionService.skipToNextAction('game-1', 'user-1');
+
+      expect(result.message).toBe('Remaining proposals skipped, moved to round summary');
+      expect(result.completedActions).toBe(2);
+      expect(db.round.update).toHaveBeenCalledWith({
+        where: { id: 'round-1' },
+        data: {
+          totalActionsRequired: 2,
+          actionsCompleted: 2,
+        },
+      });
+    });
+
+    it('should throw error if no actions exist in round', async () => {
+      const mockGame = {
+        id: 'game-1',
+        name: 'Test Game',
+        currentPhase: 'PROPOSAL',
+        currentActionId: null,
+        deletedAt: null,
+        currentRound: {
+          id: 'round-1',
+          roundNumber: 1,
+        },
+        currentAction: null,
+        players: [
+          { id: 'player-1', userId: 'user-1', isHost: true, isActive: true },
+        ],
+      };
+
+      vi.mocked(db.game.findUnique).mockResolvedValue(mockGame as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+      vi.mocked(db.action.count).mockResolvedValue(0);
+
+      await expect(actionService.skipToNextAction('game-1', 'user-1')).rejects.toThrow(
+        new BadRequestError('Cannot skip - at least one action must be proposed before moving on')
+      );
+    });
+
+    it('should throw error if not in proposal phase', async () => {
+      const mockGame = {
+        id: 'game-1',
+        name: 'Test Game',
+        currentPhase: 'ARGUMENTATION', // Wrong phase
+        currentActionId: 'action-1',
+        deletedAt: null,
+        currentRound: {
+          id: 'round-1',
+        },
+        currentAction: { id: 'action-1' },
+        players: [
+          { id: 'player-1', userId: 'user-1', isHost: true, isActive: true },
+        ],
+      };
+
+      vi.mocked(db.game.findUnique).mockResolvedValue(mockGame as any);
+      vi.mocked(db.gamePlayer.findFirst).mockResolvedValue({
+        id: 'player-1',
+        userId: 'user-1',
+        isHost: true,
+        isActive: true,
+      } as any);
+
+      await expect(actionService.skipToNextAction('game-1', 'user-1')).rejects.toThrow(
+        new BadRequestError('Cannot skip - game is not waiting for proposals')
+      );
+    });
+
+    it('should throw error if game not found', async () => {
+      vi.mocked(db.game.findUnique).mockResolvedValue(null);
+
+      await expect(actionService.skipToNextAction('game-1', 'user-1')).rejects.toThrow(
+        NotFoundError
+      );
+    });
+  });
+
+  describe('Skipped Vote Handling', () => {
+    it('auto-filled votes should have correct token distribution', () => {
+      // UNCERTAIN votes add 1 success and 1 failure token
+      const skippedVoteData = {
+        voteType: 'UNCERTAIN',
+        successTokens: 1,
+        failureTokens: 1,
+        wasSkipped: true,
+      };
+
+      expect(skippedVoteData.successTokens).toBe(1);
+      expect(skippedVoteData.failureTokens).toBe(1);
+      expect(skippedVoteData.wasSkipped).toBe(true);
+    });
+
+    it('skipped flag should be tracked on both action and individual votes', () => {
+      const actionWithSkippedVoting = {
+        votingWasSkipped: true,
+        votes: [
+          { playerId: 'p1', voteType: 'LIKELY_SUCCESS', wasSkipped: false },
+          { playerId: 'p2', voteType: 'UNCERTAIN', wasSkipped: true },
+          { playerId: 'p3', voteType: 'UNCERTAIN', wasSkipped: true },
+        ],
+      };
+
+      const skippedVotesCount = actionWithSkippedVoting.votes.filter(v => v.wasSkipped).length;
+      expect(actionWithSkippedVoting.votingWasSkipped).toBe(true);
+      expect(skippedVotesCount).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Allow game hosts to manually skip proposal/argumentation/voting phases when players take too long
- Skip proposals: ends proposal phase early, moves to round summary (requires at least one action)
- Skip argumentation: ends argument phase, moves directly to voting
- Skip voting: auto-fills missing votes as UNCERTAIN with `wasSkipped` flag, moves to resolution

## Changes
- Added `wasSkipped` field to Vote model and `argumentationWasSkipped`/`votingWasSkipped` to Action model
- Added skip service functions with proper host verification
- Added HostControls component with confirmation dialogs in sidebar
- Updated history displays to show skipped indicators
- Added unit tests for skip functionality

## Test plan
- [ ] As host, skip argumentation phase - verify transition to voting
- [ ] As host, skip voting phase - verify missing votes are auto-filled as UNCERTAIN
- [ ] As host, skip proposals - verify at least one action is required
- [ ] Verify history shows "Args skipped" and "Votes skipped" badges
- [ ] Verify skipped vote count shows in history (e.g., "3 votes, 1 auto-filled")

🤖 Generated with [Claude Code](https://claude.com/claude-code)